### PR TITLE
Add a zstyle tunable to opt for traditional backward movement

### DIFF
--- a/functions/.edit.subword
+++ b/functions/.edit.subword
@@ -2,6 +2,9 @@
 emulate -L zsh; setopt $_edit_opts
 local -i move=0
 
+local tradback
+zstyle -b ":edit:$WIDGET:" traditional-backward-movement tradback
+
 if [[ $WIDGET == *kill-* ]]; then
   zle -f kill
   if (( REGION_ACTIVE )); then
@@ -14,15 +17,23 @@ if [[ $WIDGET == *-shell-word ]]; then
   local w=
   if [[ $WIDGET == *backward* ]]; then
     local -a words=( ${(z)LBUFFER} )
-    while [[ -z $w && $#words[@] -gt 0 ]]; do
-      if [[ $words[-1] == \; ]]; then
-        w=${(M)LBUFFER%[$';\n']*}
+    if [[ $tradback != yes ]]; then
+      while [[ -z $w && $#words[@] -gt 0 ]]; do
+        if [[ $words[-1] == \; ]]; then
+          w=${(M)LBUFFER%[$';\n']*}
+        else
+          w=${(M)LBUFFER%$words[-1]*}
+        fi
+        w=${(M)LBUFFER%%[[:blank:]]#$w}
+        shift -p words
+      done
+    else
+      if [[ $#words -gt 0 ]]; then
+        w=${(M)LBUFFER%${words[-1]}[[:blank:]]#}
       else
-        w=${(M)LBUFFER%$words[-1]*}
+        w=$LBUFFER
       fi
-      w=${(M)LBUFFER%%[[:blank:]]#$w}
-      shift -p words
-    done
+    fi
     move=-$#w
   else
     # We can't split $RBUFFER on words, because that usually doesn't parse correctly.
@@ -40,14 +51,19 @@ if [[ $WIDGET == *-shell-word ]]; then
     move=+$#w
   fi
 else
-  local wordchars
+  local wordchars word
   zstyle -s ":edit:$WIDGET:" word-chars wordchars &&
       local +h WORDCHARS="$wordchars"
 
-  local word='([[:space:]]~[[:WORD:]])#([^[:WORD:][:space:]])#[[:upper:]]#([[:WORD:]]~[[:upper:]])#'
   if [[ $WIDGET == *backward-* ]]; then
+    if [[ $tradback != yes ]]; then
+      word='([[:space:]]~[[:WORD:]])#([^[:WORD:][:space:]])#[[:upper:]]#([[:WORD:]]~[[:upper:]])#'
+    else
+      word='[[:upper:]]#([[:WORD:]]~[[:upper:]])#([[:space:]]~[[:WORD:]])#([^[:WORD:][:space:]])#'
+    fi
     move=-${(M)#LBUFFER%%$~word}
   else
+    word='([[:space:]]~[[:WORD:]])#([^[:WORD:][:space:]])#[[:upper:]]#([[:WORD:]]~[[:upper:]])#'
     move=+${(M)#RBUFFER##$~word}
   fi
 fi


### PR DESCRIPTION
Like I mentioned [here](https://github.com/marlonrichert/zsh-edit/issues/13#issuecomment-1538513015), backward movements kind of radically changed, so this PR is about providing a compatibility option to make a backward movement always land on each word beginning if enabled.

Before submitting your PR (pull request), please
check the following:
* [x] There is no other PR (open or closed)
  similar to yours. If there is, please first
  discuss over there.
* [x] Each commit messages follows the [Seven
  Rules of a Great Commit
  Message](https://cbea.ms/git-commit/#seven-rules).
* [x] Each commit message includes
  `Fixes #<bug>` or `Resolves #<issue>` in its 
  body (not subject) for each issue it resolves
  (if any).
* [x] You have
  [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing)
  any redundant or insignificant commits.
